### PR TITLE
Add Nord Pool market adapter module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,8 +78,10 @@ Quants, data scientists, and developers at energy trading companies who build th
 nexa-bidkit/
   src/nexa_bidkit/
     __init__.py
-    curves.py          # merit order curve construction
     bids.py            # bid objects (hourly, block, linked, exclusive)
+    curves.py          # merit order curve construction
+    epex_spot.py       # Convert your orders to EPEX Spot domain model
+    nordpool.py        # Convert your orders to Nord Pool domain model
     orders.py          # order book / portfolio of bids
     validation.py      # bid validation rules
     types.py           # core types/enums (MTU, BiddingZone, etc.)

--- a/README.md
+++ b/README.md
@@ -254,6 +254,135 @@ The validation module enforces:
 - **Temporal constraints**: Gate closure deadlines, delivery periods within auction day
 - **Portfolio limits**: Total volume sanity checks across bidding zones
 
+### Submitting to Nord Pool
+
+The `nordpool` module converts your bids into Nord Pool Auction API request payloads.
+Because Nord Pool contract IDs (e.g. `"NO1-14"`) depend on Nord Pool's products API,
+you supply a `ContractIdResolver` callable to perform that mapping.
+
+#### Curve order from a SimpleBid
+
+```python
+from nexa_bidkit.nordpool import simple_bid_to_curve_order
+from nexa_bidkit import (
+    BiddingZone, CurveType, Direction, MTUDuration, MTUInterval,
+    PriceQuantityCurve, PriceQuantityStep, SimpleBid,
+)
+from decimal import Decimal
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+mtu = MTUInterval.from_start(
+    datetime(2026, 4, 1, 13, 0, tzinfo=ZoneInfo("Europe/Oslo")),
+    MTUDuration.HOURLY,
+)
+
+curve = PriceQuantityCurve(
+    curve_type=CurveType.SUPPLY,
+    steps=[
+        PriceQuantityStep(price=Decimal("10.00"), volume=Decimal("50")),
+        PriceQuantityStep(price=Decimal("20.00"), volume=Decimal("100")),
+    ],
+    mtu=mtu,
+)
+
+bid = SimpleBid(
+    bid_id="simple-1",
+    bidding_zone=BiddingZone.NO1,
+    direction=Direction.SELL,
+    curve=curve,
+)
+
+# Your resolver maps (MTUInterval, BiddingZone) → Nord Pool contract ID.
+# Call Nord Pool's products API to populate this lookup at runtime.
+def resolve_contract(mtu, zone):
+    hour = mtu.start.hour
+    return f"{zone.value}-{hour}"
+
+payload = simple_bid_to_curve_order(
+    bid,
+    auction_id="DA-2026-04-01",
+    portfolio="my-portfolio",
+    contract_id_resolver=resolve_contract,
+)
+
+# Serialise to JSON for the Nord Pool API (uses camelCase aliases)
+print(payload.model_dump(by_alias=True))
+# {
+#   "auctionId": "DA-2026-04-01",
+#   "portfolio": "my-portfolio",
+#   "areaCode": "NO1",
+#   "comment": null,
+#   "curves": [{"contractId": "NO1-13", "curvePoints": [...]}]
+# }
+```
+
+#### Block and linked block orders
+
+```python
+from nexa_bidkit.nordpool import block_bid_to_block_list, linked_block_bid_to_block_list
+from nexa_bidkit import (
+    BiddingZone, DeliveryPeriod, Direction, MTUDuration,
+    block_bid, linked_block_bid,
+)
+from decimal import Decimal
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+tz = ZoneInfo("Europe/Oslo")
+delivery = DeliveryPeriod(
+    start=datetime(2026, 4, 1, 10, 0, tzinfo=tz),
+    end=datetime(2026, 4, 1, 14, 0, tzinfo=tz),
+    duration=MTUDuration.HOURLY,
+)
+
+must_run = block_bid(
+    bidding_zone=BiddingZone.NO1,
+    direction=Direction.SELL,
+    delivery_period=delivery,
+    price=Decimal("25.0"),
+    volume=Decimal("50"),
+    bid_id="must-run",
+)
+
+ramp_up = linked_block_bid(
+    parent_bid_id=must_run.bid_id,
+    bidding_zone=BiddingZone.NO1,
+    direction=Direction.SELL,
+    delivery_period=delivery,
+    price=Decimal("35.0"),
+    volume=Decimal("25"),
+)
+
+block_payload  = block_bid_to_block_list(must_run, "DA-2026-04-01", "my-portfolio", resolve_contract)
+linked_payload = linked_block_bid_to_block_list(ramp_up, "DA-2026-04-01", "my-portfolio", resolve_contract)
+
+# The linked block payload carries the parent reference
+print(linked_payload.blocks[0].linked_to)  # "must-run"
+```
+
+#### Converting a whole OrderBook at once
+
+```python
+from nexa_bidkit.nordpool import order_book_to_nord_pool
+from nexa_bidkit import create_order_book, add_bids
+
+book = create_order_book()
+book = add_bids(book, [must_run, ramp_up])
+
+submission = order_book_to_nord_pool(
+    book,
+    auction_id="DA-2026-04-01",
+    portfolio="my-portfolio",
+    contract_id_resolver=resolve_contract,
+)
+
+print(f"Curve orders:        {len(submission.curve_orders)}")
+print(f"Block orders:        {len(submission.block_orders)}")
+print(f"Linked block orders: {len(submission.linked_block_orders)}")
+print(f"Exclusive groups:    {len(submission.exclusive_group_orders)}")
+```
+
 ## Core Concepts
 
 ### Market Time Units (MTU)

--- a/src/nexa_bidkit/nordpool.py
+++ b/src/nexa_bidkit/nordpool.py
@@ -1,0 +1,519 @@
+"""Nord Pool market adapter for nexa-bidkit.
+
+Converts internal bid objects into Nord Pool Auction API request schemas.
+Supports curve orders (SimpleBid) and block/linked/exclusive-group orders.
+
+Nord Pool operates in the Nordic and Baltic bidding zones. Unsupported zones
+(CWE, Iberian, Italian, GB) raise ValueError.
+
+Callers must supply a ``ContractIdResolver`` to map MTU intervals to Nord Pool
+contract ID strings (e.g. ``"NO1-14"``), since these IDs require a call to
+Nord Pool's products API and are not derivable from the bid data alone.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from nexa_bidkit.bids import BlockBid, ExclusiveGroupBid, LinkedBlockBid, SimpleBid
+from nexa_bidkit.orders import OrderBook
+from nexa_bidkit.types import BiddingZone, Direction, MTUInterval
+
+# ---------------------------------------------------------------------------
+# Type alias
+# ---------------------------------------------------------------------------
+
+ContractIdResolver = Callable[[MTUInterval, BiddingZone], str]
+"""Callable that maps an MTU interval + bidding zone to a Nord Pool contract ID."""
+
+
+# ---------------------------------------------------------------------------
+# Nord Pool request Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class CurvePoint(BaseModel):
+    """A single point on a Nord Pool price-quantity curve.
+
+    Attributes:
+        price: Price in EUR/MWh (float, Nord Pool API convention).
+        volume: Volume in MW. Positive = sell, negative = buy.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    price: float
+    volume: float
+
+
+class Curve(BaseModel):
+    """A price-quantity curve for a single Nord Pool contract.
+
+    Attributes:
+        contract_id: Nord Pool contract identifier (e.g. ``"NO1-14"``).
+        curve_points: Ordered list of price-quantity points.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    contract_id: str = Field(alias="contractId")
+    curve_points: list[CurvePoint] = Field(alias="curvePoints")
+
+
+class CurveOrderCreate(BaseModel):
+    """Nord Pool API payload for submitting a curve (simple) order.
+
+    Attributes:
+        auction_id: Auction identifier.
+        portfolio: Portfolio name.
+        area_code: Nord Pool area code derived from the bidding zone.
+        comment: Optional free-text comment.
+        curves: List of per-contract curves.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    auction_id: str = Field(alias="auctionId")
+    portfolio: str
+    area_code: str = Field(alias="areaCode")
+    comment: str | None = Field(default=None)
+    curves: list[Curve]
+
+
+class BlockPeriod(BaseModel):
+    """A single MTU period within a Nord Pool block order.
+
+    Attributes:
+        contract_id: Nord Pool contract identifier for this MTU.
+        volume: Volume in MW. Positive = sell, negative = buy.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    contract_id: str = Field(alias="contractId")
+    volume: float
+
+
+class Block(BaseModel):
+    """A single block within a Nord Pool block list order.
+
+    Attributes:
+        name: Block identifier (typically the internal bid_id).
+        price: Limit price in EUR/MWh.
+        minimum_acceptance_ratio: Minimum partial fill ratio (0–1).
+        periods: Per-MTU periods making up the block.
+        linked_to: Parent block name for linked blocks.
+        exclusive_group: Exclusive group identifier.
+        is_spread_block: Whether this is a spread block (default False).
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: str
+    price: float
+    minimum_acceptance_ratio: float = Field(alias="minimumAcceptanceRatio")
+    periods: list[BlockPeriod]
+    linked_to: str | None = Field(default=None, alias="linkedTo")
+    exclusive_group: str | None = Field(default=None, alias="exclusiveGroup")
+    is_spread_block: bool = Field(default=False, alias="isSpreadBlock")
+
+
+class BlockListCreate(BaseModel):
+    """Nord Pool API payload for submitting a list of block orders.
+
+    Attributes:
+        auction_id: Auction identifier.
+        portfolio: Portfolio name.
+        area_code: Nord Pool area code derived from the bidding zone.
+        comment: Optional free-text comment.
+        blocks: List of block orders to submit.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    auction_id: str = Field(alias="auctionId")
+    portfolio: str
+    area_code: str = Field(alias="areaCode")
+    comment: str | None = Field(default=None)
+    blocks: list[Block]
+
+
+# ---------------------------------------------------------------------------
+# Submission container
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class NordPoolSubmission:
+    """All Nord Pool API request payloads derived from an OrderBook.
+
+    Attributes:
+        curve_orders: One :class:`CurveOrderCreate` per :class:`SimpleBid`.
+        block_orders: One :class:`BlockListCreate` per :class:`BlockBid`.
+        linked_block_orders: One :class:`BlockListCreate` per :class:`LinkedBlockBid`.
+        exclusive_group_orders: One :class:`BlockListCreate` per :class:`ExclusiveGroupBid`.
+    """
+
+    curve_orders: list[CurveOrderCreate] = field(default_factory=list)
+    block_orders: list[BlockListCreate] = field(default_factory=list)
+    linked_block_orders: list[BlockListCreate] = field(default_factory=list)
+    exclusive_group_orders: list[BlockListCreate] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Bidding zone → Nord Pool area code
+# ---------------------------------------------------------------------------
+
+_AREA_CODE_MAP: dict[BiddingZone, str] = {
+    BiddingZone.NO1: "NO1",
+    BiddingZone.NO2: "NO2",
+    BiddingZone.NO3: "NO3",
+    BiddingZone.NO4: "NO4",
+    BiddingZone.NO5: "NO5",
+    BiddingZone.SE1: "SE1",
+    BiddingZone.SE2: "SE2",
+    BiddingZone.SE3: "SE3",
+    BiddingZone.SE4: "SE4",
+    BiddingZone.FI: "FI",
+    BiddingZone.DK1: "DK1",
+    BiddingZone.DK2: "DK2",
+    BiddingZone.EE: "EE",
+    BiddingZone.LV: "LV",
+    BiddingZone.LT: "LT",
+    BiddingZone.PL: "PL",
+}
+
+
+def bidding_zone_to_area_code(zone: BiddingZone) -> str:
+    """Convert a BiddingZone to a Nord Pool area code string.
+
+    Args:
+        zone: The bidding zone to convert.
+
+    Returns:
+        The Nord Pool area code string (e.g. ``"NO1"``).
+
+    Raises:
+        ValueError: If the zone is not supported by Nord Pool
+            (e.g. CWE, Iberian, Italian, or GB zones).
+    """
+    try:
+        return _AREA_CODE_MAP[zone]
+    except KeyError as exc:
+        raise ValueError(
+            f"Bidding zone {zone.value!r} is not supported by Nord Pool. "
+            "Nord Pool operates Nordic (NO1-NO5, SE1-SE4, FI, DK1, DK2) "
+            "and Baltic (EE, LV, LT) zones only."
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _signed_volume(volume: float, direction: Direction) -> float:
+    """Return volume with sign convention: SELL = positive, BUY = negative."""
+    return volume if direction == Direction.SELL else -volume
+
+
+# ---------------------------------------------------------------------------
+# Conversion functions
+# ---------------------------------------------------------------------------
+
+
+def simple_bid_to_curve_order(
+    bid: SimpleBid,
+    auction_id: str,
+    portfolio: str,
+    contract_id_resolver: ContractIdResolver,
+    comment: str | None = None,
+) -> CurveOrderCreate:
+    """Convert a :class:`SimpleBid` to a Nord Pool :class:`CurveOrderCreate`.
+
+    One :class:`Curve` is created for the bid's MTU, with ``contractId``
+    resolved via ``contract_id_resolver``. Volumes are signed per Nord Pool
+    convention: positive for SELL, negative for BUY.
+
+    Args:
+        bid: The simple bid to convert.
+        auction_id: Nord Pool auction identifier.
+        portfolio: Portfolio name.
+        contract_id_resolver: Callable mapping (MTUInterval, BiddingZone) → contract ID.
+        comment: Optional free-text comment.
+
+    Returns:
+        A :class:`CurveOrderCreate` ready for submission.
+
+    Raises:
+        ValueError: If the bid's bidding zone is not supported by Nord Pool.
+    """
+    area_code = bidding_zone_to_area_code(bid.bidding_zone)
+    contract_id = contract_id_resolver(bid.curve.mtu, bid.bidding_zone)
+
+    curve_points = [
+        CurvePoint(
+            price=float(step.price),
+            volume=_signed_volume(float(step.volume), bid.direction),
+        )
+        for step in bid.curve.steps
+    ]
+
+    curve = Curve.model_validate({"contractId": contract_id, "curvePoints": curve_points})
+
+    return CurveOrderCreate.model_validate(
+        {
+            "auctionId": auction_id,
+            "portfolio": portfolio,
+            "areaCode": area_code,
+            "comment": comment,
+            "curves": [curve],
+        }
+    )
+
+
+def block_bid_to_block_list(
+    bid: BlockBid,
+    auction_id: str,
+    portfolio: str,
+    contract_id_resolver: ContractIdResolver,
+    comment: str | None = None,
+) -> BlockListCreate:
+    """Convert a :class:`BlockBid` to a Nord Pool :class:`BlockListCreate`.
+
+    One :class:`Block` is created with one :class:`BlockPeriod` per MTU interval
+    in the bid's delivery period. Volumes are signed per Nord Pool convention.
+
+    Args:
+        bid: The block bid to convert.
+        auction_id: Nord Pool auction identifier.
+        portfolio: Portfolio name.
+        contract_id_resolver: Callable mapping (MTUInterval, BiddingZone) → contract ID.
+        comment: Optional free-text comment.
+
+    Returns:
+        A :class:`BlockListCreate` ready for submission.
+
+    Raises:
+        ValueError: If the bid's bidding zone is not supported by Nord Pool.
+    """
+    area_code = bidding_zone_to_area_code(bid.bidding_zone)
+    signed_vol = _signed_volume(float(bid.volume), bid.direction)
+
+    periods = [
+        BlockPeriod.model_validate(
+            {"contractId": contract_id_resolver(mtu, bid.bidding_zone), "volume": signed_vol}
+        )
+        for mtu in bid.delivery_period.mtu_intervals()
+    ]
+
+    block = Block.model_validate(
+        {
+            "name": bid.bid_id,
+            "price": float(bid.price),
+            "minimumAcceptanceRatio": float(bid.min_acceptance_ratio),
+            "periods": periods,
+        }
+    )
+
+    return BlockListCreate.model_validate(
+        {
+            "auctionId": auction_id,
+            "portfolio": portfolio,
+            "areaCode": area_code,
+            "comment": comment,
+            "blocks": [block],
+        }
+    )
+
+
+def linked_block_bid_to_block_list(
+    bid: LinkedBlockBid,
+    auction_id: str,
+    portfolio: str,
+    contract_id_resolver: ContractIdResolver,
+    comment: str | None = None,
+) -> BlockListCreate:
+    """Convert a :class:`LinkedBlockBid` to a Nord Pool :class:`BlockListCreate`.
+
+    Same as :func:`block_bid_to_block_list` but sets ``linkedTo`` on the block
+    to reference the parent bid ID.
+
+    Args:
+        bid: The linked block bid to convert.
+        auction_id: Nord Pool auction identifier.
+        portfolio: Portfolio name.
+        contract_id_resolver: Callable mapping (MTUInterval, BiddingZone) → contract ID.
+        comment: Optional free-text comment.
+
+    Returns:
+        A :class:`BlockListCreate` with ``linkedTo`` populated, ready for submission.
+
+    Raises:
+        ValueError: If the bid's bidding zone is not supported by Nord Pool.
+    """
+    area_code = bidding_zone_to_area_code(bid.bidding_zone)
+    signed_vol = _signed_volume(float(bid.volume), bid.direction)
+
+    periods = [
+        BlockPeriod.model_validate(
+            {"contractId": contract_id_resolver(mtu, bid.bidding_zone), "volume": signed_vol}
+        )
+        for mtu in bid.delivery_period.mtu_intervals()
+    ]
+
+    block = Block.model_validate(
+        {
+            "name": bid.bid_id,
+            "price": float(bid.price),
+            "minimumAcceptanceRatio": float(bid.min_acceptance_ratio),
+            "periods": periods,
+            "linkedTo": bid.parent_bid_id,
+        }
+    )
+
+    return BlockListCreate.model_validate(
+        {
+            "auctionId": auction_id,
+            "portfolio": portfolio,
+            "areaCode": area_code,
+            "comment": comment,
+            "blocks": [block],
+        }
+    )
+
+
+def exclusive_group_to_block_list(
+    group: ExclusiveGroupBid,
+    auction_id: str,
+    portfolio: str,
+    contract_id_resolver: ContractIdResolver,
+    comment: str | None = None,
+) -> BlockListCreate:
+    """Convert an :class:`ExclusiveGroupBid` to a Nord Pool :class:`BlockListCreate`.
+
+    Each member :class:`BlockBid` becomes a :class:`Block` with ``exclusiveGroup``
+    set to the group's ``group_id``. All blocks share the same ``areaCode``.
+
+    Args:
+        group: The exclusive group bid to convert.
+        auction_id: Nord Pool auction identifier.
+        portfolio: Portfolio name.
+        contract_id_resolver: Callable mapping (MTUInterval, BiddingZone) → contract ID.
+        comment: Optional free-text comment.
+
+    Returns:
+        A :class:`BlockListCreate` with all member blocks tagged with ``exclusiveGroup``.
+
+    Raises:
+        ValueError: If the group's bidding zone is not supported by Nord Pool.
+    """
+    area_code = bidding_zone_to_area_code(group.bidding_zone)
+
+    blocks = []
+    for member in group.block_bids:
+        signed_vol = _signed_volume(float(member.volume), member.direction)
+        periods = [
+            BlockPeriod.model_validate(
+                {"contractId": contract_id_resolver(mtu, member.bidding_zone), "volume": signed_vol}
+            )
+            for mtu in member.delivery_period.mtu_intervals()
+        ]
+        blocks.append(
+            Block.model_validate(
+                {
+                    "name": member.bid_id,
+                    "price": float(member.price),
+                    "minimumAcceptanceRatio": float(member.min_acceptance_ratio),
+                    "periods": periods,
+                    "exclusiveGroup": group.group_id,
+                }
+            )
+        )
+
+    return BlockListCreate.model_validate(
+        {
+            "auctionId": auction_id,
+            "portfolio": portfolio,
+            "areaCode": area_code,
+            "comment": comment,
+            "blocks": blocks,
+        }
+    )
+
+
+def order_book_to_nord_pool(
+    order_book: OrderBook,
+    auction_id: str,
+    portfolio: str,
+    contract_id_resolver: ContractIdResolver,
+    comment: str | None = None,
+) -> NordPoolSubmission:
+    """Convert an :class:`OrderBook` into a :class:`NordPoolSubmission`.
+
+    Iterates all bids in the order book and dispatches each to the appropriate
+    conversion function, grouping outputs by bid type.
+
+    Args:
+        order_book: The order book to convert.
+        auction_id: Nord Pool auction identifier.
+        portfolio: Portfolio name.
+        contract_id_resolver: Callable mapping (MTUInterval, BiddingZone) → contract ID.
+        comment: Optional free-text comment attached to all generated requests.
+
+    Returns:
+        A :class:`NordPoolSubmission` containing all generated API payloads.
+
+    Raises:
+        ValueError: If any bid's bidding zone is not supported by Nord Pool.
+    """
+    submission = NordPoolSubmission()
+
+    for bid in order_book.bids:
+        if isinstance(bid, SimpleBid):
+            submission.curve_orders.append(
+                simple_bid_to_curve_order(bid, auction_id, portfolio, contract_id_resolver, comment)
+            )
+        elif isinstance(bid, LinkedBlockBid):
+            submission.linked_block_orders.append(
+                linked_block_bid_to_block_list(
+                    bid, auction_id, portfolio, contract_id_resolver, comment
+                )
+            )
+        elif isinstance(bid, BlockBid):
+            submission.block_orders.append(
+                block_bid_to_block_list(bid, auction_id, portfolio, contract_id_resolver, comment)
+            )
+        elif isinstance(bid, ExclusiveGroupBid):
+            submission.exclusive_group_orders.append(
+                exclusive_group_to_block_list(
+                    group=bid,
+                    auction_id=auction_id,
+                    portfolio=portfolio,
+                    contract_id_resolver=contract_id_resolver,
+                    comment=comment,
+                )
+            )
+
+    return submission
+
+
+__all__ = [
+    "ContractIdResolver",
+    "CurvePoint",
+    "Curve",
+    "CurveOrderCreate",
+    "BlockPeriod",
+    "Block",
+    "BlockListCreate",
+    "NordPoolSubmission",
+    "bidding_zone_to_area_code",
+    "simple_bid_to_curve_order",
+    "block_bid_to_block_list",
+    "linked_block_bid_to_block_list",
+    "exclusive_group_to_block_list",
+    "order_book_to_nord_pool",
+]

--- a/tests/test_nordpool.py
+++ b/tests/test_nordpool.py
@@ -1,0 +1,536 @@
+"""Tests for nexa_bidkit.nordpool — Nord Pool market adapter."""
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from nexa_bidkit.bids import (
+    BlockBid,
+    ExclusiveGroupBid,
+    LinkedBlockBid,
+    SimpleBid,
+    exclusive_group,
+)
+from nexa_bidkit.nordpool import (
+    BlockListCreate,
+    CurveOrderCreate,
+    NordPoolSubmission,
+    bidding_zone_to_area_code,
+    block_bid_to_block_list,
+    exclusive_group_to_block_list,
+    linked_block_bid_to_block_list,
+    order_book_to_nord_pool,
+    simple_bid_to_curve_order,
+)
+from nexa_bidkit.orders import OrderBook, add_bid, create_order_book
+from nexa_bidkit.types import (
+    BiddingZone,
+    CurveType,
+    DeliveryPeriod,
+    Direction,
+    MTUDuration,
+    MTUInterval,
+    PriceQuantityCurve,
+    PriceQuantityStep,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+T0 = datetime(2026, 4, 1, 10, 0, 0, tzinfo=UTC)
+AUCTION_ID = "DA-2026-04-01"
+PORTFOLIO = "test-portfolio"
+
+
+def _mtu(start: datetime = T0, duration: MTUDuration = MTUDuration.HOURLY) -> MTUInterval:
+    return MTUInterval.from_start(start, duration)
+
+
+def _delivery_period(
+    start: datetime = T0,
+    hours: int = 2,
+    duration: MTUDuration = MTUDuration.HOURLY,
+) -> DeliveryPeriod:
+    return DeliveryPeriod(start=start, end=start + timedelta(hours=hours), duration=duration)
+
+
+def _supply_curve(start: datetime = T0) -> PriceQuantityCurve:
+    return PriceQuantityCurve(
+        curve_type=CurveType.SUPPLY,
+        steps=[
+            PriceQuantityStep(price=Decimal("10.00"), volume=Decimal("50")),
+            PriceQuantityStep(price=Decimal("20.00"), volume=Decimal("100")),
+        ],
+        mtu=_mtu(start),
+    )
+
+
+def _demand_curve(start: datetime = T0) -> PriceQuantityCurve:
+    return PriceQuantityCurve(
+        curve_type=CurveType.DEMAND,
+        steps=[
+            PriceQuantityStep(price=Decimal("80.00"), volume=Decimal("30")),
+            PriceQuantityStep(price=Decimal("40.00"), volume=Decimal("60")),
+        ],
+        mtu=_mtu(start),
+    )
+
+
+def _simple_sell_bid(start: datetime = T0) -> SimpleBid:
+    return SimpleBid(
+        bid_id="simple-sell-1",
+        bidding_zone=BiddingZone.NO1,
+        direction=Direction.SELL,
+        curve=_supply_curve(start),
+    )
+
+
+def _simple_buy_bid(start: datetime = T0) -> SimpleBid:
+    return SimpleBid(
+        bid_id="simple-buy-1",
+        bidding_zone=BiddingZone.NO1,
+        direction=Direction.BUY,
+        curve=_demand_curve(start),
+    )
+
+
+def _block_sell_bid(bid_id: str = "block-1", zone: BiddingZone = BiddingZone.NO1) -> BlockBid:
+    return BlockBid(
+        bid_id=bid_id,
+        bidding_zone=zone,
+        direction=Direction.SELL,
+        delivery_period=_delivery_period(),
+        price=Decimal("45.00"),
+        volume=Decimal("100"),
+        min_acceptance_ratio=Decimal("0.5"),
+    )
+
+
+def _block_buy_bid(bid_id: str = "block-buy-1") -> BlockBid:
+    return BlockBid(
+        bid_id=bid_id,
+        bidding_zone=BiddingZone.NO1,
+        direction=Direction.BUY,
+        delivery_period=_delivery_period(),
+        price=Decimal("60.00"),
+        volume=Decimal("80"),
+    )
+
+
+def _contract_resolver(mtu: MTUInterval, zone: BiddingZone) -> str:
+    """Simple resolver: zone-value + hour offset from T0."""
+    offset_hours = int((mtu.start - T0).total_seconds() // 3600)
+    return f"{zone.value}-{10 + offset_hours}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: bidding_zone_to_area_code
+# ---------------------------------------------------------------------------
+
+
+class TestBiddingZoneToAreaCode:
+    def test_nordic_zones_map_correctly(self) -> None:
+        assert bidding_zone_to_area_code(BiddingZone.NO1) == "NO1"
+        assert bidding_zone_to_area_code(BiddingZone.NO5) == "NO5"
+        assert bidding_zone_to_area_code(BiddingZone.SE3) == "SE3"
+        assert bidding_zone_to_area_code(BiddingZone.FI) == "FI"
+        assert bidding_zone_to_area_code(BiddingZone.DK1) == "DK1"
+        assert bidding_zone_to_area_code(BiddingZone.DK2) == "DK2"
+
+    def test_baltic_zones_map_correctly(self) -> None:
+        assert bidding_zone_to_area_code(BiddingZone.EE) == "EE"
+        assert bidding_zone_to_area_code(BiddingZone.LV) == "LV"
+        assert bidding_zone_to_area_code(BiddingZone.LT) == "LT"
+
+    def test_pl_maps_correctly(self) -> None:
+        assert bidding_zone_to_area_code(BiddingZone.PL) == "PL"
+
+    def test_unsupported_cwe_de_lu_raises(self) -> None:
+        with pytest.raises(ValueError, match="not supported by Nord Pool"):
+            bidding_zone_to_area_code(BiddingZone.DE_LU)
+
+    def test_unsupported_fr_raises(self) -> None:
+        with pytest.raises(ValueError, match="not supported by Nord Pool"):
+            bidding_zone_to_area_code(BiddingZone.FR)
+
+    def test_unsupported_gb_raises(self) -> None:
+        with pytest.raises(ValueError, match="not supported by Nord Pool"):
+            bidding_zone_to_area_code(BiddingZone.GB)
+
+    def test_unsupported_italian_zone_raises(self) -> None:
+        with pytest.raises(ValueError, match="not supported by Nord Pool"):
+            bidding_zone_to_area_code(BiddingZone.IT_NORD)
+
+    def test_unsupported_iberian_zone_raises(self) -> None:
+        with pytest.raises(ValueError, match="not supported by Nord Pool"):
+            bidding_zone_to_area_code(BiddingZone.ES)
+
+
+# ---------------------------------------------------------------------------
+# Tests: simple_bid_to_curve_order
+# ---------------------------------------------------------------------------
+
+
+class TestSimpleBidToCurveOrder:
+    def test_returns_curve_order_create(self) -> None:
+        bid = _simple_sell_bid()
+        result = simple_bid_to_curve_order(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert isinstance(result, CurveOrderCreate)
+
+    def test_auction_id_and_portfolio(self) -> None:
+        bid = _simple_sell_bid()
+        result = simple_bid_to_curve_order(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert result.auction_id == AUCTION_ID
+        assert result.portfolio == PORTFOLIO
+
+    def test_area_code_set_from_zone(self) -> None:
+        bid = _simple_sell_bid()
+        result = simple_bid_to_curve_order(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert result.area_code == "NO1"
+
+    def test_contract_id_from_resolver(self) -> None:
+        bid = _simple_sell_bid()
+        result = simple_bid_to_curve_order(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert len(result.curves) == 1
+        assert result.curves[0].contract_id == "NO1-10"
+
+    def test_sell_volumes_are_positive(self) -> None:
+        bid = _simple_sell_bid()
+        result = simple_bid_to_curve_order(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        for point in result.curves[0].curve_points:
+            assert point.volume > 0
+
+    def test_buy_volumes_are_negative(self) -> None:
+        bid = _simple_buy_bid()
+        result = simple_bid_to_curve_order(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        for point in result.curves[0].curve_points:
+            assert point.volume < 0
+
+    def test_curve_points_count_matches_steps(self) -> None:
+        bid = _simple_sell_bid()
+        result = simple_bid_to_curve_order(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert len(result.curves[0].curve_points) == len(bid.curve.steps)
+
+    def test_comment_passed_through(self) -> None:
+        bid = _simple_sell_bid()
+        result = simple_bid_to_curve_order(
+            bid, AUCTION_ID, PORTFOLIO, _contract_resolver, comment="my comment"
+        )
+        assert result.comment == "my comment"
+
+    def test_comment_none_by_default(self) -> None:
+        bid = _simple_sell_bid()
+        result = simple_bid_to_curve_order(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert result.comment is None
+
+    def test_unsupported_zone_raises(self) -> None:
+        bid = SimpleBid(
+            bid_id="cwe-bid",
+            bidding_zone=BiddingZone.DE_LU,
+            direction=Direction.SELL,
+            curve=PriceQuantityCurve(
+                curve_type=CurveType.SUPPLY,
+                steps=[PriceQuantityStep(price=Decimal("10"), volume=Decimal("50"))],
+                mtu=_mtu(),
+            ),
+        )
+        with pytest.raises(ValueError, match="not supported by Nord Pool"):
+            simple_bid_to_curve_order(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+
+
+# ---------------------------------------------------------------------------
+# Tests: block_bid_to_block_list
+# ---------------------------------------------------------------------------
+
+
+class TestBlockBidToBlockList:
+    def test_returns_block_list_create(self) -> None:
+        bid = _block_sell_bid()
+        result = block_bid_to_block_list(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert isinstance(result, BlockListCreate)
+
+    def test_area_code_set_from_zone(self) -> None:
+        bid = _block_sell_bid()
+        result = block_bid_to_block_list(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert result.area_code == "NO1"
+
+    def test_one_block_per_bid(self) -> None:
+        bid = _block_sell_bid()
+        result = block_bid_to_block_list(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert len(result.blocks) == 1
+
+    def test_block_name_is_bid_id(self) -> None:
+        bid = _block_sell_bid(bid_id="my-block")
+        result = block_bid_to_block_list(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert result.blocks[0].name == "my-block"
+
+    def test_block_price_converted_to_float(self) -> None:
+        bid = _block_sell_bid()
+        result = block_bid_to_block_list(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert result.blocks[0].price == pytest.approx(45.0)
+
+    def test_mar_converted_to_float(self) -> None:
+        bid = _block_sell_bid()
+        result = block_bid_to_block_list(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert result.blocks[0].minimum_acceptance_ratio == pytest.approx(0.5)
+
+    def test_periods_match_mtu_intervals(self) -> None:
+        bid = _block_sell_bid()
+        result = block_bid_to_block_list(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        expected_count = bid.delivery_period.mtu_count
+        assert len(result.blocks[0].periods) == expected_count
+
+    def test_sell_periods_have_positive_volume(self) -> None:
+        bid = _block_sell_bid()
+        result = block_bid_to_block_list(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        for period in result.blocks[0].periods:
+            assert period.volume > 0
+
+    def test_buy_periods_have_negative_volume(self) -> None:
+        bid = _block_buy_bid()
+        result = block_bid_to_block_list(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        for period in result.blocks[0].periods:
+            assert period.volume < 0
+
+    def test_period_contract_ids_from_resolver(self) -> None:
+        bid = _block_sell_bid()
+        result = block_bid_to_block_list(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        periods = result.blocks[0].periods
+        assert periods[0].contract_id == "NO1-10"
+        assert periods[1].contract_id == "NO1-11"
+
+    def test_linked_to_not_set(self) -> None:
+        bid = _block_sell_bid()
+        result = block_bid_to_block_list(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert result.blocks[0].linked_to is None
+
+    def test_exclusive_group_not_set(self) -> None:
+        bid = _block_sell_bid()
+        result = block_bid_to_block_list(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert result.blocks[0].exclusive_group is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: linked_block_bid_to_block_list
+# ---------------------------------------------------------------------------
+
+
+class TestLinkedBlockBidToBlockList:
+    def _linked_bid(self) -> LinkedBlockBid:
+        return LinkedBlockBid(
+            bid_id="linked-1",
+            parent_bid_id="block-1",
+            bidding_zone=BiddingZone.NO1,
+            direction=Direction.SELL,
+            delivery_period=_delivery_period(start=T0 + timedelta(hours=2)),
+            price=Decimal("50.00"),
+            volume=Decimal("75"),
+            min_acceptance_ratio=Decimal("0.75"),
+        )
+
+    def test_linked_to_set_from_parent_bid_id(self) -> None:
+        bid = self._linked_bid()
+        result = linked_block_bid_to_block_list(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert result.blocks[0].linked_to == "block-1"
+
+    def test_returns_block_list_create(self) -> None:
+        bid = self._linked_bid()
+        result = linked_block_bid_to_block_list(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert isinstance(result, BlockListCreate)
+
+    def test_block_name_is_bid_id(self) -> None:
+        bid = self._linked_bid()
+        result = linked_block_bid_to_block_list(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert result.blocks[0].name == "linked-1"
+
+    def test_periods_match_mtu_count(self) -> None:
+        bid = self._linked_bid()
+        result = linked_block_bid_to_block_list(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert len(result.blocks[0].periods) == bid.delivery_period.mtu_count
+
+    def test_mar_carried_through(self) -> None:
+        bid = self._linked_bid()
+        result = linked_block_bid_to_block_list(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert result.blocks[0].minimum_acceptance_ratio == pytest.approx(0.75)
+
+    def test_exclusive_group_not_set(self) -> None:
+        bid = self._linked_bid()
+        result = linked_block_bid_to_block_list(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert result.blocks[0].exclusive_group is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: exclusive_group_to_block_list
+# ---------------------------------------------------------------------------
+
+
+class TestExclusiveGroupToBlockList:
+    def _group(self) -> ExclusiveGroupBid:
+        bid_a = BlockBid(
+            bid_id="excl-a",
+            bidding_zone=BiddingZone.NO2,
+            direction=Direction.SELL,
+            delivery_period=_delivery_period(),
+            price=Decimal("40.00"),
+            volume=Decimal("50"),
+        )
+        bid_b = BlockBid(
+            bid_id="excl-b",
+            bidding_zone=BiddingZone.NO2,
+            direction=Direction.SELL,
+            delivery_period=_delivery_period(start=T0 + timedelta(hours=4)),
+            price=Decimal("45.00"),
+            volume=Decimal("60"),
+        )
+        return exclusive_group([bid_a, bid_b], group_id="grp-1")
+
+    def test_returns_block_list_create(self) -> None:
+        grp = self._group()
+        result = exclusive_group_to_block_list(grp, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert isinstance(result, BlockListCreate)
+
+    def test_area_code_from_group_zone(self) -> None:
+        grp = self._group()
+        result = exclusive_group_to_block_list(grp, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert result.area_code == "NO2"
+
+    def test_all_blocks_have_exclusive_group_set(self) -> None:
+        grp = self._group()
+        result = exclusive_group_to_block_list(grp, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        for block in result.blocks:
+            assert block.exclusive_group == "grp-1"
+
+    def test_block_count_matches_members(self) -> None:
+        grp = self._group()
+        result = exclusive_group_to_block_list(grp, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert len(result.blocks) == grp.member_count
+
+    def test_block_names_from_member_bid_ids(self) -> None:
+        grp = self._group()
+        result = exclusive_group_to_block_list(grp, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        names = {b.name for b in result.blocks}
+        assert names == {"excl-a", "excl-b"}
+
+    def test_linked_to_not_set(self) -> None:
+        grp = self._group()
+        result = exclusive_group_to_block_list(grp, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        for block in result.blocks:
+            assert block.linked_to is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: order_book_to_nord_pool
+# ---------------------------------------------------------------------------
+
+
+class TestOrderBookToNordPool:
+    def _mixed_order_book(self) -> OrderBook:
+        parent_bid = _block_sell_bid(bid_id="parent-block")
+        linked = LinkedBlockBid(
+            bid_id="linked-x",
+            parent_bid_id="parent-block",
+            bidding_zone=BiddingZone.NO1,
+            direction=Direction.SELL,
+            delivery_period=_delivery_period(start=T0 + timedelta(hours=2)),
+            price=Decimal("50.00"),
+            volume=Decimal("50"),
+        )
+        excl_a = BlockBid(
+            bid_id="excl-a",
+            bidding_zone=BiddingZone.NO1,
+            direction=Direction.SELL,
+            delivery_period=_delivery_period(start=T0 + timedelta(hours=4)),
+            price=Decimal("30.00"),
+            volume=Decimal("40"),
+        )
+        excl_b = BlockBid(
+            bid_id="excl-b",
+            bidding_zone=BiddingZone.NO1,
+            direction=Direction.SELL,
+            delivery_period=_delivery_period(start=T0 + timedelta(hours=6)),
+            price=Decimal("35.00"),
+            volume=Decimal("45"),
+        )
+        grp = exclusive_group([excl_a, excl_b], group_id="grp-1")
+        simple = _simple_sell_bid(start=T0 + timedelta(hours=8))
+
+        ob = create_order_book()
+        ob = add_bid(ob, simple)
+        ob = add_bid(ob, parent_bid)
+        ob = add_bid(ob, linked)
+        ob = add_bid(ob, grp)
+        return ob
+
+    def test_returns_nord_pool_submission(self) -> None:
+        ob = self._mixed_order_book()
+        result = order_book_to_nord_pool(ob, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert isinstance(result, NordPoolSubmission)
+
+    def test_simple_bids_go_to_curve_orders(self) -> None:
+        ob = self._mixed_order_book()
+        result = order_book_to_nord_pool(ob, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert len(result.curve_orders) == 1
+        assert isinstance(result.curve_orders[0], CurveOrderCreate)
+
+    def test_block_bids_go_to_block_orders(self) -> None:
+        ob = self._mixed_order_book()
+        result = order_book_to_nord_pool(ob, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert len(result.block_orders) == 1
+
+    def test_linked_bids_go_to_linked_block_orders(self) -> None:
+        ob = self._mixed_order_book()
+        result = order_book_to_nord_pool(ob, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert len(result.linked_block_orders) == 1
+        assert result.linked_block_orders[0].blocks[0].linked_to == "parent-block"
+
+    def test_exclusive_groups_go_to_exclusive_group_orders(self) -> None:
+        ob = self._mixed_order_book()
+        result = order_book_to_nord_pool(ob, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert len(result.exclusive_group_orders) == 1
+
+    def test_empty_order_book_returns_empty_submission(self) -> None:
+        ob = create_order_book()
+        result = order_book_to_nord_pool(ob, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert result.curve_orders == []
+        assert result.block_orders == []
+        assert result.linked_block_orders == []
+        assert result.exclusive_group_orders == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: Decimal → float conversion
+# ---------------------------------------------------------------------------
+
+
+class TestPriceVolumeDecimalToFloat:
+    def test_curve_point_price_is_float(self) -> None:
+        bid = _simple_sell_bid()
+        result = simple_bid_to_curve_order(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        for point in result.curves[0].curve_points:
+            assert isinstance(point.price, float)
+
+    def test_curve_point_volume_is_float(self) -> None:
+        bid = _simple_sell_bid()
+        result = simple_bid_to_curve_order(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        for point in result.curves[0].curve_points:
+            assert isinstance(point.volume, float)
+
+    def test_block_price_is_float(self) -> None:
+        bid = _block_sell_bid()
+        result = block_bid_to_block_list(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        assert isinstance(result.blocks[0].price, float)
+
+    def test_block_period_volume_is_float(self) -> None:
+        bid = _block_sell_bid()
+        result = block_bid_to_block_list(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        for period in result.blocks[0].periods:
+            assert isinstance(period.volume, float)
+
+    def test_decimal_precision_preserved_in_conversion(self) -> None:
+        bid = _simple_sell_bid()
+        result = simple_bid_to_curve_order(bid, AUCTION_ID, PORTFOLIO, _contract_resolver)
+        prices = [pt.price for pt in result.curves[0].curve_points]
+        assert prices[0] == pytest.approx(10.0)
+        assert prices[1] == pytest.approx(20.0)


### PR DESCRIPTION
## Summary

- Implements `nordpool.py` — converts internal bid objects into Nord Pool Auction API request payloads (`CurveOrderCreate`, `BlockListCreate`)
- Supports all four bid types: `SimpleBid` → curve orders; `BlockBid`, `LinkedBlockBid`, `ExclusiveGroupBid` → block list orders
- `ContractIdResolver` type alias lets callers supply their own MTU → contract ID mapping (requires Nord Pool products API at runtime)
- Bidding zone → area code mapping covering Nordic (NO1–NO5, SE1–SE4, FI, DK1, DK2) and Baltic (EE, LV, LT) zones; unsupported zones raise `ValueError`
- `order_book_to_nord_pool()` converts a whole `OrderBook` into a `NordPoolSubmission` in one call
- 53 tests in `tests/test_nordpool.py`, 100% coverage on `nordpool.py`, overall suite at 98.42%
- README updated with three worked examples (curve order, block/linked orders, full order book conversion)

## Test plan

- [x] `make test` — 308 tests pass, coverage 98.42% (target ≥ 97.89%)
- [x] `poetry run mypy src` — no type errors
- [x] `poetry run ruff check src tests` — no lint errors
- [x] `poetry run ruff format src tests` — no formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)