### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nexa-bidkit"
-version = "1.0.0"
+version = "1.1.0"
 description = "Day-ahead and intraday auction bid generation for European power markets"
 authors = []
 readme = "README.md"


### PR DESCRIPTION
Version bump for stable release 1.1.0.

## Summary
- Bumps version from 1.0.0 → 1.1.0 in `pyproject.toml`

## What's new in 1.1.0
- EXAA exchange adapter (`nexa_bidkit.exaa`) — converts bids to EXAA Trading API payloads, supporting hourly, 15-minute, and block products